### PR TITLE
Fix fuzz

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-cardinality-estimator = { path = "..", features = ["with_serde"] }
+cardinality-estimator-safe = { path = "..", features = ["with_serde"] }
 libfuzzer-sys = "0.4"
 postcard = { version = "1.1.1", features = ["alloc"] }
 serde_json = "1.0.115"

--- a/fuzz/fuzz_targets/serde.rs
+++ b/fuzz/fuzz_targets/serde.rs
@@ -1,10 +1,11 @@
 #![no_main]
 
-use cardinality_estimator_safe::estimator::CardinalityEstimator;
+use cardinality_estimator_safe::{CardinalityEstimator, Representation};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(mut estimator) = serde_json::from_slice::<CardinalityEstimator<usize>>(data) {
+    if let Ok(rep) = serde_json::from_slice::<Representation>(data) {
+        let mut estimator: CardinalityEstimator<usize> = rep.into();
         estimator.insert(&1);
         assert!(estimator.estimate() > 0);
     }

--- a/fuzz/fuzz_targets/serde_json_array.rs
+++ b/fuzz/fuzz_targets/serde_json_array.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use serde_json::Value;
-use cardinality_estimator_safe::estimator::CardinalityEstimator;
+use cardinality_estimator_safe::{CardinalityEstimator, Representation};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -12,7 +12,8 @@ fuzz_target!(|data: &[u8]| {
         _ => Value::Array(vec![data[0].into(),
             Value::Array(data[1..].iter().map(|n| (*n).into()).collect())]),
     };
-    if let Ok(mut estimator) = serde_json::from_value::<CardinalityEstimator<usize>>(json) {
+    if let Ok(rep) = serde_json::from_value::<Representation>(json) {
+        let mut estimator: CardinalityEstimator<usize> = rep.into();
         estimator.insert(&1);
         assert!(estimator.estimate() > 0);
     }

--- a/fuzz/fuzz_targets/serde_postcard.rs
+++ b/fuzz/fuzz_targets/serde_postcard.rs
@@ -1,10 +1,11 @@
 #![no_main]
 
-use cardinality_estimator_safe::estimator::CardinalityEstimator;
+use cardinality_estimator_safe::{CardinalityEstimator, Representation};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(mut estimator) = postcard::from_bytes::<CardinalityEstimator<usize>>(data) {
+    if let Ok(rep) = postcard::from_bytes::<Representation>(data) {
+        let mut estimator: CardinalityEstimator<usize> = rep.into();
         estimator.insert(&1);
         assert!(estimator.estimate() > 0);
     }

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -41,11 +41,10 @@ impl<const P: usize, const W: usize> HyperLogLog<P, W> {
     /// Create new instance of `HyperLogLog` representation from items
     #[inline]
     pub(crate) fn new(items: &[u32]) -> Self {
-        // TODO: this is wrong, need to actually compute things
         let mut hll = Self {
             zeros: Self::M as u32,
             harmonic_sum: Self::M as f32,
-            registers: vec![0; Self::HLL_SLICE_LEN],
+            registers: vec![0; Self::HLL_SLICE_LEN], // TODO: reserve exact?
         };
 
         for &h in items.iter() {

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -129,6 +129,7 @@ impl<const P: usize, const W: usize> HyperLogLog<P, W> {
 
     /// Merge two `HyperLogLog` representations.
     #[inline]
+    #[cfg(feature = "with_serde")]
     pub(crate) fn from_registers(registers: Vec<u32>) -> Self {
         assert_eq!(Self::HLL_SLICE_LEN, registers.len());
         let mut lhs = Self::new(&[]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,3 +57,4 @@ mod serde;
 mod small;
 
 pub use estimator::*;
+pub use representation::Representation;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,6 +1,60 @@
 //! # Serde module for CardinalityEstimator
-//!
-//! This module now only provides basic tests for derived serializationa and deserialization.
+
+use serde::{Deserialize, Serialize, ser::SerializeSeq};
+use serde::de::{self, Visitor, SeqAccess};
+use crate::hyperloglog::HyperLogLog;
+use std::fmt;
+
+
+impl<const P: usize, const W: usize> Serialize for HyperLogLog<P, W> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer
+    {
+        assert_eq!(Self::HLL_SLICE_LEN, self.registers.len());
+        let mut tup = serializer.serialize_seq(Some(Self::HLL_SLICE_LEN))?;
+        for r in &self.registers {
+            tup.serialize_element(r)?;
+        }
+        tup.end()
+    }
+}
+
+struct TupleU32Visitor(usize);
+
+impl<'de> Visitor<'de> for TupleU32Visitor {
+    type Value = Vec<u32>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a tuple of u32s")
+    }
+
+    fn visit_seq<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let Self(expected_len) = self;
+        let mut registers: Self::Value = Vec::with_capacity(expected_len);
+        for i in 0..expected_len {
+            eprintln!("gettin {i} of {expected_len}...");
+            let el = access.next_element()?.ok_or_else(||
+                de::Error::custom(&format!("could not find register at index {i} (of {expected_len} expected)")))?;
+            registers.push(el);
+        }
+        Ok(registers)
+    }
+}
+
+impl<'de, const P: usize, const W: usize> Deserialize<'de> for HyperLogLog<P, W> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>
+    {
+        let registers = deserializer.deserialize_seq(TupleU32Visitor(Self::HLL_SLICE_LEN))?;
+        Ok(HyperLogLog::from_registers(registers))
+    }
+}
+
 
 #[cfg(test)]
 pub mod tests {


### PR DESCRIPTION
custom serializer (only a little gross) for hyperloglog sketch representation that only serializes the registers array, and validates the array length on deserialization

the zeros and current estimate are computed on deserialize instead of being stored. this wastes some cycles, but trusting any stored bytes without validating also feels bad (and can lead to panics that can be tricky to avoid). let's see if it's too slow.